### PR TITLE
Python3 compatible

### DIFF
--- a/sts/inetheaders.py
+++ b/sts/inetheaders.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 class Header(str):
-    def __init__(self, name):
-        str.__init__(self, name)
-        self.normalized = name.lower().strip()
+    def __new__(cls, name, *args, **kw):
+        obj = str.__new__(cls, name, *args, **kw)
+        obj.normalized = name.lower().strip()
+        return obj
 
     def __hash__(self):
         return hash(self.normalized)
@@ -51,7 +52,7 @@ COMPACT_HEADERS = dict([(Header(key), value) for key, value in {
     'X-Trace-ID': TRACE,
     'Transfer-Encoding': TRANSFER_ENCODING,
     'Via': VIA
-}.iteritems()])
+}.items()])
 
 
 MULTI_HEADERS = frozenset([Header(name) for name in [

--- a/sts/inetmsg.py
+++ b/sts/inetmsg.py
@@ -90,7 +90,7 @@ def _build_header_line(header):
 
 
 def _build_header_lines(headers):
-    return [_build_header_line(header) for header in headers.iteritems()] + ['\r\n']
+    return [_build_header_line(header) for header in headers.items()] + ['\r\n']
 
 
 def build_message(start_line, headers, body):


### PR DESCRIPTION
The python-sts module does not work with python3, since inheriting from an str seems to be slightly different from one version to another. Moreover, the `iteritems` is replaced by `items`.

One interesting thing would be to convert the CRLF to LF in every file. Have you ever thought about it?